### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+### What does this PR do?
+
+(Please set a descriptive PR title. Use this space for additional explanations.)
+
+### How does it look like?
+
+(If this is more than a textual change, a screenshot can help in some cases to speed up the review process.)
+
+### Any background context you can provide?
+
+(Please link public issues or summarize if not public.)
+
+### What is needed from the reviewers?
+
+### Why is this piece of content here?
+
+(If you are adding content, please consider adding it to the main documentation at https://docs.giantswarm.io/.)
+
+### Have you maintained the front matter?
+
+(Please bump the last_review_date in case this qualifies as a review for an entire page. Provide user_questions which should be answered in the page. Provide a meaningful description.)


### PR DESCRIPTION
### What does this PR do?

Adds a PR template which is both in line with our emerging standard and asks some questions specific to this repo.

### How does it look like?

It's here, right in front of you.

### Any background context you can provide?

This has been planned in SIG Docs. A specific goal for "handbook" is to consider whether handbook is the right context to publish something new, or whether it can be docs instead.

- [Issue](https://github.com/giantswarm/giantswarm/issues/23530)
- [Intranet article on the topic](https://intranet.giantswarm.io/docs/dev-and-releng/developer-workflow/pr-templates/)

### What is needed from the reviewers?

Nothing special.

### Why is this piece of content here?

Not applicable

### Have you maintained the front matter?

Not applicable