### PR TITLE
people: Avoid duplicate title in frontmatter

### DIFF
--- a/content/docs/people/_index.md
+++ b/content/docs/people/_index.md
@@ -1,5 +1,5 @@
 ---
-title: People and processes
+title: People
 linkTitle: People
 weight: 98
 icon: fa fa-smile

--- a/content/docs/people/_index.md
+++ b/content/docs/people/_index.md
@@ -1,5 +1,4 @@
 ---
-title: People
 title: People and processes
 linkTitle: People
 weight: 98


### PR DESCRIPTION
## Summary

Remove duplicate `title` entry in frontmatter (it kills the YAML parser).