### PR TITLE
Fix Invalid Redirect by Downstream Server in Case of Missing Trailing Slash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN hugo --verbose --gc --minify --enableGitInfo --cleanDestinationDir --destina
 FROM quay.io/giantswarm/nginx-unprivileged:1.21-alpine
 EXPOSE 8080
 USER 0
+# enable relative 301 redirects to fix invalid redirects on missing trailing slash
+# (a downstream server doesn't necessarily know the public name and port)
+RUN sed -i 's/location \/ {/location \/ {\n        absolute_redirect off;/' /etc/nginx/conf.d/default.conf
 # copy in staticly built hugo site from build step above
 COPY --from=build /src/public /usr/share/nginx/html
 USER 101


### PR DESCRIPTION
Fixes giantswarm/giantswarm#23018

## Summary

To avoid invalid 301 redirect URLs from downstream servers, one can disable absolute redirects via setting `absolute_redirect off;` in NGINX `server` or `location` context.
