### PR TITLE
Show confidentiality as tag to make it more obvious

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,9 +13,9 @@ enableGitInfo = true
 confidentiality = "confidentiality"
 
 [params.taxonomy]
-taxonomyCloud = ["confidentiality"]
-taxonomyCloudTitle = ["confidentiality"]
-taxonomyPageHeader = [] # This hides the taxonomies in the header.
+taxonomyCloud = [] # This hides the taxonomies in the sidebar.
+taxonomyCloudTitle = [] # This hides the taxonomies in the sidebar.
+taxonomyPageHeader = ["confidentiality"] 
 
 # Highlighting config
 pygmentsCodeFences = true

--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,13 @@ theme = ["docsy"]
 # Will give values to .Lastmod etc.
 enableGitInfo = true
 
-disableKinds = ["taxonomy", "taxonomyTerm"]
+[taxonomies]
+confidentiality = "confidentiality"
+
+[params.taxonomy]
+taxonomyCloud = ["confidentiality"]
+taxonomyCloudTitle = ["confidentiality"]
+taxonomyPageHeader = [] # This hides the taxonomies in the header.
 
 # Highlighting config
 pygmentsCodeFences = true


### PR DESCRIPTION
### What does this PR do?

Adds a taxonomy for confidentiality.

### How does it look like?

<img width="1487" alt="Screenshot 2023-05-05 at 16 13 10" src="https://user-images.githubusercontent.com/9303709/236482838-494c14f9-ed7d-470a-8375-5a14a50a9b51.png">

### Any background context you can provide?

We figured it's better for users to know where the confidentiality is set, without checking the source frontmatter.
