### PR TITLE
Align sidebar menu text after symbols

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,0 +1,3 @@
+.td-sidebar-link :is(i.fa, i.fas) {
+  width: 1.5em;
+}


### PR DESCRIPTION
## Summary

Align sidebar menu items' text to icons.

This minor design correction is already applied to intranet: https://github.com/giantswarm/giantswarm/pull/28070
