### PR TITLE
Add LogQL basics

### DIFF
--- a/content/docs/observability/loki-usage.md
+++ b/content/docs/observability/loki-usage.md
@@ -58,7 +58,7 @@ Used to filter text within the log stream
 
 ```
 |= : contains
-!= : does not contains
+!= : does not contain
 |~ : regex matches
 !~ : regex does not match
 ```

--- a/content/docs/observability/loki-usage.md
+++ b/content/docs/observability/loki-usage.md
@@ -35,7 +35,9 @@ confidentiality: public
 ```goat
 { installation="myInstallation", pod=~"k8s-api-server-ip-.*" } |= “unable to load root certificate”
 |                                                            |  | |                               |
-                             .+.                                |                .+.
+.-----------------------------+------------------------------.  | .---------------+---------------.
+                              |                                 |                 |
+                              v                                 v                 v
                      log stream selectors               filter operator    filter expression
 ```
 

--- a/content/docs/observability/loki-usage.md
+++ b/content/docs/observability/loki-usage.md
@@ -57,8 +57,8 @@ Used to filter the log stream by labels
 Used to filter text within the log stream
 
 ```
-|= : equals
-!= : not equals
+|= : contains
+!= : does not contains
 |~ : regex matches
 !~ : regex does not match
 ```

--- a/content/docs/observability/loki-usage.md
+++ b/content/docs/observability/loki-usage.md
@@ -28,6 +28,40 @@ confidentiality: public
 
 ![builder / code](../lokidoc-builder-code.png)
 
+## LogQL basics
+
+### Query anatomy
+
+```goat
+{ installation="myInstallation", pod=~"k8s-api-server-ip-.*" } |= “unable to load root certificate”
+|                                                            |  | |                               |
+                             .+.                                |                .+.
+                     log stream selectors               filter operator    filter expression
+```
+
+### Log stream selectors
+
+Used to filter the log stream by labels
+
+```
+=  : equals
+!= : not equals
+=~ : regex matches
+!~ : regex does not match
+```
+
+### Filter operators
+
+Used to filter text within the log stream
+
+```
+|= : equals
+!= : not equals
+|~ : regex matches
+!~ : regex does not match
+```
+
+
 ## Example of useful LogQL queries
 
 Here are a few LogQL queries you can test and play with to understand the syntax.


### PR DESCRIPTION
Add LogQL basics section to Loki usage guide, to explain how LogQL are structured

- add logql basics
- add logstream selector
- add filter operators

![image](https://github.com/giantswarm/handbook/assets/6536819/dd109767-2c70-4146-b6aa-b60bfb379790)
