### PR TITLE
fix images path for loki guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed images path in Loki usage and Loki cost guides
+
 ## [0.7.0] - 2023-09-19
 
 ### Added

--- a/content/docs/observability/loki-cost-estimate/_index.md
+++ b/content/docs/observability/loki-cost-estimate/_index.md
@@ -24,7 +24,7 @@ Loki's cost is coming from 3 different sources :
 
 The dashboard gives access to graphs related to those sources :
 
-![loki-cost-dashboard-screenshot](../images/loki-cost-dashboard.png)
+![loki-cost-dashboard-screenshot](images/loki-cost-dashboard.png)
 
 Basing on the total storage space used by Loki to store the logs as well as the base cost of the object storage service from your cloud-provider, one can roughly estimate the cost of storage for the logging-infrastructure.
 
@@ -36,14 +36,14 @@ CPU and memory cost are a bit more tricky to quantify, but it's still possible t
 
 Alongside the dashboard mentioned above, if the logging infrastructure is running on an AWS installation, one can open the AWS console and navigate to the Cost Explorer service. There, select the time period to be evaluated as well as the tag `giantswarm.io/installation` with the value corresponding to the installation's name:
 
-![cost-explorer-tag](../images/cost-explorer-tag.png)
+![cost-explorer-tag](images/cost-explorer-tag.png)
 
 In addition to those parameters, one can increase the graph's precision by grouping the result by services:
 
-![cost-explorer-service](../images/cost-explorer-group-by.png)
+![cost-explorer-service](images/cost-explorer-group-by.png)
 
 By selecting those parameters, one can generate a similar looking graph:
 
-![cost-explorer](../images/aws-cost-explorer.png)
+![cost-explorer](images/aws-cost-explorer.png)
 
 Using the graphs it's possible to compare the general cost of the installation between time periods with or without enabled logging infrastructure.

--- a/content/docs/observability/loki-usage/_index.md
+++ b/content/docs/observability/loki-usage/_index.md
@@ -8,7 +8,7 @@ confidentiality: public
 
 ## Context
 
-<img src="../images/loki-context.png" alt="loki available on AWS, no WC logs, all components, access via Grafana, 1 month retention" >
+<img src="images/loki-context.png" alt="loki available on AWS, no WC logs, all components, access via Grafana, 1 month retention" >
 
 ## How to access Logs ?
 
@@ -22,8 +22,8 @@ confidentiality: public
    * `builder` and play with the dropdowns to build your query
    * `code` to write your query using [LogQL](https://grafana.com/docs/loki/latest/logql/)
 
-<img src="../images/lokidoc-explore.png" width="300" >
-<img src="../images/lokidoc-datasource-query.png" width="600" >
+<img src="images/lokidoc-explore.png" width="300" >
+<img src="images/lokidoc-datasource-query.png" width="600" >
 
 ## LogQL basics
 


### PR DESCRIPTION
This PR fixed images path in Loki usage and Loki cost guides.
This was broken by https://github.com/giantswarm/handbook/pull/127