### PR TITLE
Add instructions for creating a new Go repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add instructions on how to create a new Go repo.
+
 ## [0.7.1] - 2023-09-21
 
 ### Fixed

--- a/content/docs/dev-and-releng/repository/_index.md
+++ b/content/docs/dev-and-releng/repository/_index.md
@@ -1,0 +1,9 @@
+---
+linkTitle: Create new repository
+title: Creating a new GitHub repository
+description: For a new component, and for many other purposes, we create dedicated repositories in Github. Here is how you do it best, to ensure consistency and to have all features and automation available.
+---
+
+Technically, you can simply hit the "Create repository" button in Github. But that means you'll have to do a lot of manual work afterwards, so better keep reading here.
+
+Please select the right type of repository to create from the available sub pages to learn more.

--- a/content/docs/dev-and-releng/repository/_index.md
+++ b/content/docs/dev-and-releng/repository/_index.md
@@ -4,6 +4,6 @@ title: Creating a new GitHub repository
 description: For a new component, and for many other purposes, we create dedicated repositories in Github. Here is how you do it best, to ensure consistency and to have all features and automation available.
 ---
 
-Technically, you can simply hit the "Create repository" button in Github. But that means you'll have to do a lot of manual work afterwards, so better keep reading here.
+Technically, you could simply hit the "Create repository" button in Github. But that would mean you'll have to do a lot of manual work afterwards, so better keep reading here.
 
 Please select the right type of repository to create from the available sub pages to learn more.

--- a/content/docs/dev-and-releng/repository/go/_index.md
+++ b/content/docs/dev-and-releng/repository/go/_index.md
@@ -4,7 +4,7 @@ title: Creating a new Go/Golang repository
 description: The canonical way to create a new Go repository.
 ---
 
-These instructions will help you create a new Go (aka Golang) project repository based on our [template](https://github.com/giantswarm/template).
+These instructions will help you create a new Go (a.k.a. Golang) project repository based on our [template](https://github.com/giantswarm/template).
 
 ## Prerequisites
 

--- a/content/docs/dev-and-releng/repository/go/_index.md
+++ b/content/docs/dev-and-releng/repository/go/_index.md
@@ -1,0 +1,97 @@
+---
+linkTitle: Golang
+title: Creating a new Go/Golang repository
+description: The canonical way to create a new Go repository.
+---
+
+These instructions will help you create a new Go (aka Golang) project repository based on our [template](https://github.com/giantswarm/template).
+
+## Prerequisites
+
+- the `git` CLI
+- the [GitHub CLI](https://cli.github.com/) `gh`
+- [`devctl`](https://github.com/giantswarm/devctl) version 6.12.0 or newer
+
+## Step 1 - Preparation
+
+Since you will need the repository name several times on the command line, we first create an environment variable `REPOSITORY_NAME` with the new repository name as the value.
+
+Example:
+
+```nohighlight
+export REPOSITORY_NAME=test-repo
+```
+
+Here we assume you want to create the new repository named `test-repo`.
+
+## Step 2 - Repo creation
+
+In your current command line / shell session, navigate to the directory where you keep git clones.
+
+**Note:** No need to create an empty sub folder just for the new repo, as this will happen automatically in the next step.
+
+Now create the repository, using our [template](https://github.com/giantswarm/template) to pre-fill its content. Execute this command to create the new **public** repository:
+
+```nohighlight
+gh repo create \
+  --clone \
+  --public \
+  --template=giantswarm/template \
+  giantswarm/${REPOSITORY_NAME}
+```
+
+Note: At Giant Swarm, most of our software development is done in public under the Apache 2.0 license. You can replace the flag `--public` with `--private` to start with a private repository instead.
+
+## Step 3 - Name replacement
+
+Let's fill in the actual repository name in a bunch of places in the new repo's content, as otherwise we would have just the placeholder `REPOSITORY_NAME` in there.
+
+Make sure to navigate into your local clone of the repository:
+
+```nohighlight
+cd ${REPOSITORY_NAME}
+```
+
+Here is your command to run:
+
+```nohighlight
+devctl replace \
+  -i 'REPOSITORY_NAME' ${REPOSITORY_NAME} \
+  --ignore '.git/**' '**'
+```
+
+Commit and push these replacements:
+
+```nohighlight
+git commit -a -m "Replace placeholder by ${REPOSITORY_NAME}"
+git push origin $(git rev-parse --abbrev-ref HEAD)
+```
+
+## Step 4 - Configure settings
+
+Now configure the GitHub repository settings (permission, branch protection, etc.) with one simple command:
+
+```nohighlight
+devctl repo setup giantswarm/${REPOSITORY_NAME}
+```
+
+If you also intend to have Mend Renovate provide automatic pull requests to update dependencies, also execute this:
+
+```nohighlight
+devctl repo setup renovate giantswarm/${REPOSITORY_NAME}
+```
+
+## Step 5 - Set up repository automation
+
+To maintain team ownership and keep the repository up-to-date with our standards, you should add the new repository to your team's list in [giantswarm/github](https://github.com/giantswarm/github/tree/main/repositories). See the [README](https://github.com/giantswarm/github) for more details.
+
+## Step 6 - Create a container repo
+
+To build containers for the new repository, [set up a Quay.io repository](https://intranet.giantswarm.io/docs/dev-and-releng/container-registry/) for it.
+
+## Step 7 - Final touches
+
+- On the repository home page near `About`, click the cog icon to adjust the repository description and tags. Under "Include in the home page" de-select the Packages and Environments options.
+- Add documentation to the `docs/` folder.
+- Add badges to the README top if you like. Find some suggestions in the README of your new repo.
+- Replace the `README.md` of your new repository with meaningful info about the software you're offering there.


### PR DESCRIPTION
The idea of this new page is to consolidate these two:

- https://github.com/giantswarm/github/blob/main/README.md
- https://github.com/giantswarm/template/blob/main/README.md

(at least the aspects about creating and configuring the new repo).