### PR TITLE
Fix multiple secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Fix secret template to output more than one secret
+
 ## [0.10.2] - 2023-10-13
 
 - Fix secret templates and values

--- a/helm/handbook/templates/secrets.yaml
+++ b/helm/handbook/templates/secrets.yaml
@@ -16,4 +16,5 @@ data:
   {{- range $idx, $datum := $secret.data }}
   {{ $datum.key }}: {{ $datum.value }}
   {{- end }}
+---
 {{- end }}

--- a/helm/handbook/templates/secrets.yaml
+++ b/helm/handbook/templates/secrets.yaml
@@ -17,4 +17,4 @@ data:
   {{ $datum.key }}: {{ $datum.value }}
   {{- end }}
 ---
-{{- end }}
+{{ end }}


### PR DESCRIPTION
## Summary

The chart wasn't able to output multiple secrets from `secrets.yaml`, due to missing document separators. This PR fixes that.

@marians Do you know where the template for this generic `secrets.yaml` (I took it from `area-oncall-scheduler` and modified it for this apps needs) stems from?

I searched and found https://github.com/giantswarm/template-app but it doesn't contain any template to specifically deal with secrets.

It may make sense to add the trailing document separator to the range block, if there is a template somewhere.
