### PR TITLE
cms: mention extensions in debugging instructions

### DIFF
--- a/proxy/proxy-cms-admin-dev.conf
+++ b/proxy/proxy-cms-admin-dev.conf
@@ -15,7 +15,7 @@
 #     - podman run -it -p 8082:80 --env-file .env staticjscms-standalone:latest
 #   3. static-cms: run in live-reload "dev mode" listening on http://localhost:8080
 #     - copy handbook/cms/cms-config-dev.yml to static-cms/core/dev-test/config.yml  (must have GitHub backend with "base_url: http://localhost:8081")
-#     - Empty static-cms/core/dev-test/index.js and insert only `CMS.init();`
+#     - Replace the content of static-cms/core/dev-test/index.js with the <script> content of https://github.com/giantswarm/staticjscms-hugo-standalone/blob/master/app/staticcms/public/index.html
 #     - OPTIONAL: change the "repo: giantswarm/handbook" to a fork for testing or development purposes
 #     - run: yarn dev
 #   4. visit http://localhost:8081/admin/


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28834

### Summary

Mention how to copy over the external customizations/extensions to Static CMS for the development setup.