### PR TITLE
Use staticjscms-hugo-standalone v0.0.2

### DIFF
--- a/helm/handbook/values.yaml
+++ b/helm/handbook/values.yaml
@@ -1,4 +1,4 @@
-staticJsCmsHugoStandaloneVersion: v0.0.1
+staticJsCmsHugoStandaloneVersion: v0.0.2
 
 secrets:
   # Information for staticjscms-hugo-standalone and its OAuth proxy component


### PR DESCRIPTION
### Summary

Switch to https://github.com/giantswarm/staticjscms-hugo-standalone/releases/tag/v0.0.2
