### PR TITLE
Rely on CODEOWNERS to add sig-docs to RFC rendering PRs

### DIFF
--- a/.github/workflows/render-rfcs-pr.yaml
+++ b/.github/workflows/render-rfcs-pr.yaml
@@ -53,5 +53,9 @@ jobs:
             to keep rendered RFCs in the handbook up to date.
 
             Please review and merge, or check in `#sig-docs` chat if something is wrong.
-          team-reviewers: |
-            giantswarm/sig-docs
+          # This does not work if triggered from the `rfc` repo (https://github.com/giantswarm/rfc/blob/main/.github/workflows/render.yaml) due to error
+          # "Unable to request reviewers. If requesting team reviewers a 'repo' scoped PAT is required." (using Taylor Bot token).
+          # So instead, sig-docs was added to CODEOWNERS on RFC-related paths.
+          # ---
+          # team-reviewers: |
+          #   giantswarm/sig-docs

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,6 @@
 * @giantswarm/team-team
 
+# For auto-generated PRs (see `.github/workflows/render-rfcs-pr.yaml`)
+/content/docs/rfcs @giantswarm/sig-docs
+
 /content/docs/support-and-ops/support/ @giantswarm/chapter-se


### PR DESCRIPTION
### What does this PR do?

Triggering the workflow from the `rfc` repo could not request reviewers on the autogenerated PR. If we trigger the action on the `handbook` repo by schedule or manually, it works. I guess it's because we use the Taylor Bot token. To make things easier, let's try to use the `CODEOWNERS` file instead of failing to request reviewers (hopefully the only error). The rationale is described in code so we know what the problem was and how it relates to the `rfc` repo.

Untested since we'd need to merge this first 😞.