### PR TITLE
Fix 404s: Kyverno policy, distribution cache

### DIFF
--- a/content/docs/rfcs/defaulting-capi-clusters/_index.md
+++ b/content/docs/rfcs/defaulting-capi-clusters/_index.md
@@ -57,7 +57,7 @@ It will be necessary to package webhooks (such as `Kyverno policies`) as apps wh
 
 The workflow for a developer to add a new default configuration is then the following:
 1. `Developer` adds logic to new defaulting (e.g. a `kyverno policy`).
-2. `Developer` adds templating to the app (e.g. [kyverno policies for aws](https://github.com/giantswarm/kyverno-policies/blob/main/helm/policies-aws/values.yaml) with local defaults in `values.yaml`.
+2. `Developer` adds templating to the app (e.g. [kyverno policies](https://github.com/giantswarm/kyverno-policies/tree/main/helm/kyverno-policies/charts/kyverno-policies) with local defaults in `values.yaml`.
 3. `Developer` adds global and installation specific defaults through the [config](https://github.com/giantswarm/config) repository.
 
 The workflow for a developer to then update the default configuration is simple:

--- a/content/docs/rfcs/single-registry-architecture/cache.md
+++ b/content/docs/rfcs/single-registry-architecture/cache.md
@@ -19,13 +19,13 @@ There are at least a few solutions possible, below is a list of solutions evalua
   - Tested it, but I unfortunately [couldn't make it work](https://github.com/mcronce/oci-registry/issues/14) even for a simple test case, doesn't seem to be well supported.
 - [ACR connected registry](https://learn.microsoft.com/en-us/azure/container-registry/intro-connected-registry)
         - there's no mention of how to deploy outside of AKS edge cluster, seems Azure IoT edge thing only
-- [docker's distribution/distribution](https://github.com/distribution/distribution)
+- [docker's distribution/distribution](https://distribution.github.io/distribution/about/)
   - one instance can proxy only for a single upstream registry (but that's OK for us)
   - tested, works with `containerd` for single upstream repo, works as well with `helm` charts
   - no extra dependencies, can work with just local filesystem storage
   - exposes reasonable prometheus metrics (transfer times, cache hit ratio)
-  - <https://github.com/distribution/distribution/blob/main/docs/configuration.md#proxy>
-  - <https://github.com/docker/docs/blob/main/content/registry/recipes/mirror.md>
+  - <https://distribution.github.io/distribution/recipes/nginx/>
+  - <https://distribution.github.io/distribution/recipes/mirror/>
 - [zot](https://github.com/project-zot)
   - full standalone OCI registry that directly implements OCI standards
   - reviewed when in `v2.0.0-rc6`, while majority of docs are valid for `v1.4.3`


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/29446

### Summary

Fixes broken links (upstream moved content) leading to HTTP 404s.

Affected areas:
- Kyverno policy templates
- CNCF distribution registry as cache references

### Reviewer please

Check if my information is correct or if there is better information (eg. another location for the Kyverno templates).