### PR TITLE
Switch staticjscms-hugo-standalone image: ghcr.io -> gsoci.azurecr.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Render RFCs
 - Updated Loki handbook by fixing some queries
 - Synchronize local environment (docker-compose.yaml) with updated production environment
+- Switch to public `staticjscms-hugo-standalone` image instead of private ghcr.io one
 
 ## [0.11.0] - 2023-10-19
 

--- a/cms/Dockerfile.cms
+++ b/cms/Dockerfile.cms
@@ -1,5 +1,5 @@
 # use minimal nginx alpine image for proxying to hugo and decap-cms containers
-FROM quay.io/giantswarm/staticjscms-hugo-standalone:latest
+FROM gsoci.azurecr.io/giantswarm/staticjscms-hugo-standalone:latest
 
 # add customized Decap CMS config for handbook
 COPY cms-config-dev.yaml /app/config.yml

--- a/helm/handbook/templates/staticjscms-deployment.yaml
+++ b/helm/handbook/templates/staticjscms-deployment.yaml
@@ -30,7 +30,7 @@ spec:
               weight: 100
       containers:
         - name: staticjscms-hugo-standalone
-          image: quay.io/giantswarm/staticjscms-hugo-standalone:{{ .Values.staticJsCmsHugoStandaloneVersion }}
+          image: gsoci.azurecr.io/giantswarm/staticjscms-hugo-standalone:{{ .Values.staticJsCmsHugoStandaloneVersion }}
           imagePullPolicy: Always
           env:
             - name: ORIGINS

--- a/helm/handbook/templates/staticjscms-deployment.yaml
+++ b/helm/handbook/templates/staticjscms-deployment.yaml
@@ -30,7 +30,7 @@ spec:
               weight: 100
       containers:
         - name: staticjscms-hugo-standalone
-          image: ghcr.io/giantswarm/staticjscms-hugo-standalone:{{ .Values.staticJsCmsHugoStandaloneVersion }}
+          image: quay.io/giantswarm/staticjscms-hugo-standalone:{{ .Values.staticJsCmsHugoStandaloneVersion }}
           imagePullPolicy: Always
           env:
             - name: ORIGINS
@@ -77,5 +77,3 @@ spec:
         {{- .Values.volumes | toYaml | nindent 8 }}
       serviceAccount: handbook
       serviceAccountName: handbook
-      imagePullSecrets:
-        - name: staticjscms-hugo-standalone-pull-secret

--- a/helm/handbook/values.yaml
+++ b/helm/handbook/values.yaml
@@ -1,4 +1,4 @@
-staticJsCmsHugoStandaloneVersion: v0.0.2
+staticJsCmsHugoStandaloneVersion: v0.0.5
 
 secrets:
   # Information for staticjscms-hugo-standalone and its OAuth proxy component
@@ -12,10 +12,6 @@ secrets:
         value: "YWFkc3NhZGFkYWRhZGFkMTIzMTIzMTIzMWFkYWRhZDEyMzEyM2FiYw=="
       - key: GIT_HOSTNAME
         value: ""
-  - name: staticjscms-hugo-standalone-pull-secret
-    data:
-      - key: .dockerconfigjson
-        value: "ewogICAgICAgICAgICAiYXV0aHMiOiB7CiAgICAgICAgICAgICAgImdoY3IuaW8iOiB7CiAgICAgICAgICAgICAgICAiYXV0aCI6ICJZbXhoWW14aE9tSnNZV0pzWVFvPSIKICAgICAgICAgICAgICB9CiAgICAgICAgICAgIH0KICAgICAgICAgIH0="
   - name: cms-config
     data:
       - key: config.yml

--- a/helm/handbook/values.yaml
+++ b/helm/handbook/values.yaml
@@ -1,4 +1,4 @@
-staticJsCmsHugoStandaloneVersion: v0.0.5
+staticJsCmsHugoStandaloneVersion: v0.0.6
 
 secrets:
   # Information for staticjscms-hugo-standalone and its OAuth proxy component


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28072

### Summary

Following up on https://github.com/giantswarm/giantswarm/issues/29569, we shall now switch to the public image output by our standard CI pipeline.

Extra pull secrets are no longer necessary, this PR removes them from the app's template.