### PR TITLE
Prepare for k8s 1.25

### DIFF
--- a/helm/handbook/templates/handbook-deployment.yaml
+++ b/helm/handbook/templates/handbook-deployment.yaml
@@ -19,6 +19,8 @@ spec:
     spec:
       securityContext:
         runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -31,6 +33,14 @@ spec:
       containers:
         - name: handbook
           image: gsoci.azurecr.io/giantswarm/handbook:{{ .Chart.Version }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 8080
               name: http

--- a/helm/handbook/templates/handbook-deployment.yaml
+++ b/helm/handbook/templates/handbook-deployment.yaml
@@ -30,7 +30,7 @@ spec:
             weight: 100
       containers:
         - name: handbook
-          image: quay.io/giantswarm/handbook:{{ .Chart.Version }}
+          image: gsoci.azurecr.io/giantswarm/handbook:{{ .Chart.Version }}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/helm/handbook/templates/handbook-deployment.yaml
+++ b/helm/handbook/templates/handbook-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: intranet
+  namespace: {{ .Release.Namespace }}
   name: handbook
   labels:
     app: handbook

--- a/helm/handbook/templates/handbook-deployment.yaml
+++ b/helm/handbook/templates/handbook-deployment.yaml
@@ -31,7 +31,6 @@ spec:
       containers:
         - name: handbook
           image: gsoci.azurecr.io/giantswarm/handbook:{{ .Chart.Version }}
-          imagePullPolicy: Always
           ports:
             - containerPort: 8080
               name: http

--- a/helm/handbook/templates/handbook-service.yaml
+++ b/helm/handbook/templates/handbook-service.yaml
@@ -1,7 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  namespace: intranet
+  namespace: {{ .Release.Namespace }}
   name: handbook
   labels:
     app: handbook

--- a/helm/handbook/templates/ingress.yaml
+++ b/helm/handbook/templates/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  namespace: intranet
+  namespace: {{ .Release.Namespace }}
   name: handbook
   labels:
     app: handbook

--- a/helm/handbook/templates/pdb.yaml
+++ b/helm/handbook/templates/pdb.yaml
@@ -2,7 +2,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: handbook
-  namespace: intranet
+  namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: 1
   selector:

--- a/helm/handbook/templates/psp-rbac.yaml
+++ b/helm/handbook/templates/psp-rbac.yaml
@@ -25,12 +25,6 @@ spec:
   - configMap
   - emptyDir
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  namespace: intranet
-  name: handbook
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/helm/handbook/templates/psp-rbac.yaml
+++ b/helm/handbook/templates/psp-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if not (((.Values.global).podSecurityStandards).enforced) }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -58,3 +59,4 @@ subjects:
 - kind: ServiceAccount
   name: handbook
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/handbook/templates/psp-rbac.yaml
+++ b/helm/handbook/templates/psp-rbac.yaml
@@ -34,7 +34,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: handbook
-  namespace: intranet
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
   - extensions
@@ -49,7 +49,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: handbook
-  namespace: intranet
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -57,4 +57,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: handbook
-  namespace: intranet
+  namespace: {{ .Release.Namespace }}

--- a/helm/handbook/templates/sa.yaml
+++ b/helm/handbook/templates/sa.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: handbook
+  namespace: {{ .Release.Namespace }}

--- a/helm/handbook/templates/staticjscms-deployment.yaml
+++ b/helm/handbook/templates/staticjscms-deployment.yaml
@@ -19,6 +19,8 @@ spec:
     spec:
       securityContext:
         runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -31,6 +33,14 @@ spec:
       containers:
         - name: staticjscms-hugo-standalone
           image: gsoci.azurecr.io/giantswarm/staticjscms-hugo-standalone:{{ .Values.staticJsCmsHugoStandaloneVersion }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: ORIGINS
               valueFrom:

--- a/helm/handbook/templates/staticjscms-deployment.yaml
+++ b/helm/handbook/templates/staticjscms-deployment.yaml
@@ -31,7 +31,6 @@ spec:
       containers:
         - name: staticjscms-hugo-standalone
           image: gsoci.azurecr.io/giantswarm/staticjscms-hugo-standalone:{{ .Values.staticJsCmsHugoStandaloneVersion }}
-          imagePullPolicy: Always
           env:
             - name: ORIGINS
               valueFrom:

--- a/helm/handbook/templates/staticjscms-deployment.yaml
+++ b/helm/handbook/templates/staticjscms-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: intranet
+  namespace: {{ .Release.Namespace }}
   name: staticjscms-hugo-standalone
   labels:
     app: staticjscms-hugo-standalone

--- a/helm/handbook/templates/staticjscms-deployment.yaml
+++ b/helm/handbook/templates/staticjscms-deployment.yaml
@@ -42,6 +42,11 @@ spec:
               drop:
                 - ALL
           env:
+            - name: ORIGIN
+              valueFrom:
+                secretKeyRef:
+                  name: staticjscms-secret
+                  key: ORIGINS
             - name: ORIGINS
               valueFrom:
                 secretKeyRef:

--- a/helm/handbook/templates/staticjscms-service.yaml
+++ b/helm/handbook/templates/staticjscms-service.yaml
@@ -1,7 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  namespace: intranet
+  namespace: {{ .Release.Namespace }}
   name: staticjscms-hugo-standalone
   labels:
     app: staticjscms-hugo-standalone

--- a/helm/handbook/values.yaml
+++ b/helm/handbook/values.yaml
@@ -7,9 +7,9 @@ secrets:
       - key: ORIGINS
         value: aGFuZGJvb2suZ2lhbnRzd2FybS5pbw==
       - key: OAUTH_CLIENT_ID
-        value: "MjE5OTEyMzk5MWFzZGVhZGJlZWY="
+        value: MjE5OTEyMzk5MWFzZGVhZGJlZWY=
       - key: OAUTH_CLIENT_SECRET
-        value: "YWFkc3NhZGFkYWRhZGFkMTIzMTIzMTIzMWFkYWRhZDEyMzEyM2FiYw=="
+        value: YWFkc3NhZGFkYWRhZGFkMTIzMTIzMTIzMWFkYWRhZDEyMzEyM2FiYw==
       - key: GIT_HOSTNAME
         value: ""
   - name: cms-config

--- a/helm/handbook/values.yaml
+++ b/helm/handbook/values.yaml
@@ -5,7 +5,7 @@ secrets:
   - name: staticjscms-secret
     data:
       - key: ORIGINS
-        value: "aHR0cHM6Ly9oYW5kYm9vay5naWFudHN3YXJtLmlv"
+        value: aGFuZGJvb2suZ2lhbnRzd2FybS5pbw==
       - key: OAUTH_CLIENT_ID
         value: "MjE5OTEyMzk5MWFzZGVhZGJlZWY="
       - key: OAUTH_CLIENT_SECRET

--- a/helm/handbook/values.yaml
+++ b/helm/handbook/values.yaml
@@ -29,3 +29,7 @@ volumeMounts:
   - name: cms-config
     mountPath: "/app/config.yml"
     subPath: "config.yml"
+
+global:
+  podSecurityStandards:
+    enforced: false


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29470

### What does this PR do?

Prepares the app to be deployed to gazelle / operations which is K8s 1.25 with PSS enforced.

In detail:

- Add security spec for PSS to deployments
- Add a switch to only render PSP resources if `.Values.global.podSecurityStandards.enforced` is not true
- Set namespace based on helm `.Release.Namespace`
- Change a registry to gsoci
- Remove an image pull policy (Always)