### PR TITLE
Spawn less markdown-link-check instances

### DIFF
--- a/.github/workflows/check-markdown-links.yaml
+++ b/.github/workflows/check-markdown-links.yaml
@@ -5,11 +5,17 @@ jobs:
     name: Broken Links
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Clone repository content
         uses: actions/checkout@v4
-      - name: Run link check
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
-          use-quiet-mode: 'yes'
-          folder-path: 'content/docs/'
-          config-file: '.github/workflows/markdown-link-check.json'
+          show-progress: false
+
+      - name: Install markdown-link-check
+        run: npm install -g markdown-link-check@3.11.2
+
+      - name: Run markdown-link-check
+        run: |
+          find content/docs -type f -name '*.md' | \
+              xargs markdown-link-check \
+                --quiet \
+                --config ./.github/workflows/markdown-link-check.json

--- a/.github/workflows/markdown-link-check.json
+++ b/.github/workflows/markdown-link-check.json
@@ -62,6 +62,15 @@
     },
     {
       "pattern": "https://github.com/giantswarm/pr-generator"
+    },
+    {
+      "pattern": "https://docs.google.com/document/d/"
+    },
+    {
+      "pattern": "https://docs.google.com/document/d/"
+    },
+    {
+      "pattern": "https://docs.google.com/spreadsheets/d/"
     }
   ]
 }

--- a/content/docs/dev-and-releng/app-developer-processes/creating_app_catalog.md
+++ b/content/docs/dev-and-releng/app-developer-processes/creating_app_catalog.md
@@ -20,7 +20,7 @@ file to github.
 the `write` permission to the repository.
 
 Catalogs don't drive their content. After creating the catalog, every application that wants to be included
-in it needs to have a correct [circleci.com](https://circleci.com) pipeline (see [below](#packaging-and-pushing-apps-into-an-app-catalog)).
+in it needs to have a correct [circleci.com](https://circleci.com) pipeline (see [below](#adding-an-app-catalog-to-a-management-cluster)).
 The pipeline is responsible for building the Helm chart and including it in the catalog and its index file.
 
 ## Adding an app catalog to a management cluster

--- a/content/docs/glossary/_index.md
+++ b/content/docs/glossary/_index.md
@@ -22,7 +22,7 @@ confidentiality: public
 
 Someone who is responsible for the information flow between your team and a certain SIG (both directions). See [Ambassadors for SIGs]().
 
-### Area {#area}
+### Area
 
 A combination of multiple teams e.g. the "Kubernetes as a Service" (KaaS) Area.
 
@@ -62,7 +62,7 @@ Deprecated. The former name associated with the [multi-account support](#multi-a
 
 A group of people with the same role (possibly limited by [Area](#area)) like PEs of SaaS Area, POs, SAs, Recruiters, Sales.
 
-### Client certificate {#client-certificate}
+### Client certificate
 
 X.509 certificate used by a client to authenticate with a server. In the Giant Swarm context, client certificates are a common authentication means (but not the only one) for the Kubernetes API. For example, we provide tooling to help end users create client certificates to access their workload clusters.
 
@@ -88,7 +88,7 @@ Do not use:
 
 ## E
 
-### End to end (E2E) test {#e2e-test}
+### End to end (E2E) test
 
 An automated test for an application flow from start to end. To simulate real user scenarios and validate the system under test.
 
@@ -130,7 +130,7 @@ The overall environment managed for a customer used as a landing zone by Giant S
 
 An integration test tests an individual component to expose defects in that component or how it interacts with other components.
 
-For Giant Swarm an example is a test for an operator which runs in a [KIND](#kind) cluster in Circle CI. It differs from an [end-to-end test](#e2e-test) which tests an entire Giant Swarm release.
+For Giant Swarm an example is a test for an operator which runs in a [KIND](#kind) cluster in Circle CI. It differs from an [end-to-end test](#end-to-end-e2e-test) which tests an entire Giant Swarm release.
 
 ---
 
@@ -207,7 +207,7 @@ Internally this is also often abbreviated as `MAPI`, however we don't use that a
 
 Spelling: Always spelled `Management API` with an uppercase `M`.
 
-### Multi-account support {#multi-account-support}
+### Multi-account support
 
 The ability for a management cluster to manage accounts and launch workload clusters outside its default accounts. The functionality formerly known as Bring Your Own Cloud (BYOC).
 

--- a/content/docs/support-and-ops/ops-recipes/cilium-troubleshooting.md
+++ b/content/docs/support-and-ops/ops-recipes/cilium-troubleshooting.md
@@ -8,10 +8,10 @@ confidentiality: public
 If we suspect the CNI is misbehaving 
 
 # Table of Contents
-1. [Command Line Tool](#Command-Line-Tool)
-1. [Check Component Status](#Check-Component-Status)
-1. [Cilium Connectivity Test](#Cilium-Connectivity-Test)
-1. [Check Hubble UI](#Hubble-UI)
+1. [Command Line Tool](#command-line-tool)
+1. [Check Component Status](#check-component-status)
+1. [Cilium Connectivity Test](#cilium-connectivity-test)
+1. [Check Hubble UI](#hubble-ui)
 
 ## Command Line Tool
 

--- a/content/docs/support-and-ops/ops-recipes/master-machine-usage-too-high.md
+++ b/content/docs/support-and-ops/ops-recipes/master-machine-usage-too-high.md
@@ -5,80 +5,74 @@ owner:
 confidentiality: public
 ---
 
-What to do once we are paged byWorkload Cluster master machine CPU usage is too high. 
-
-# Table of Contents
-1. [Identify the culprit](#identify-the-culprit)
-2. [Download the Git Repository source](#Download-the-Git-Repository-source)
-3. [Stop GitOps reconciliation](#Stop-GitOps-reconciliation)
-
+What to do once we are paged for "workload cluster master machine CPU usage is too high". 
 
 ## Identify the culprit
 
-1) Check the master conditions to see if kubelet has reported any problem
+1. Check the master conditions to see if kubelet has reported any problem
+    
+    ```
+    » kubectl describe node master-XXXX
+    ...
+    Conditions:
+      Type                 Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message
+      ----                 ------  -----------------                 ------------------                ------                       -------
+      NetworkUnavailable   False   Tue, 11 Apr 2023 11:30:18 +0200   Tue, 11 Apr 2023 11:30:18 +0200   CiliumIsUp                   Cilium is running on this node
+      MemoryPressure       False   Thu, 04 May 2023 12:28:22 +0200   Fri, 28 Apr 2023 16:08:33 +0200   KubeletHasSufficientMemory   kubelet has sufficient memory available
+      DiskPressure         False   Thu, 04 May 2023 12:28:22 +0200   Fri, 28 Apr 2023 16:08:33 +0200   KubeletHasNoDiskPressure     kubelet has no disk pressure
+      PIDPressure          False   Thu, 04 May 2023 12:28:22 +0200   Fri, 28 Apr 2023 16:08:33 +0200   KubeletHasSufficientPID      kubelet has sufficient PID available
+      Ready                True    Thu, 04 May 2023 12:28:22 +0200   Fri, 28 Apr 2023 16:08:33 +0200   KubeletReady                 kubelet is posting ready status
+    ```
+    
+    There you can see if network, memory or disk could be behind the problem.
 
-```
-» kubectl describe node master-XXXX
-...
-Conditions:
-  Type                 Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message
-  ----                 ------  -----------------                 ------------------                ------                       -------
-  NetworkUnavailable   False   Tue, 11 Apr 2023 11:30:18 +0200   Tue, 11 Apr 2023 11:30:18 +0200   CiliumIsUp                   Cilium is running on this node
-  MemoryPressure       False   Thu, 04 May 2023 12:28:22 +0200   Fri, 28 Apr 2023 16:08:33 +0200   KubeletHasSufficientMemory   kubelet has sufficient memory available
-  DiskPressure         False   Thu, 04 May 2023 12:28:22 +0200   Fri, 28 Apr 2023 16:08:33 +0200   KubeletHasNoDiskPressure     kubelet has no disk pressure
-  PIDPressure          False   Thu, 04 May 2023 12:28:22 +0200   Fri, 28 Apr 2023 16:08:33 +0200   KubeletHasSufficientPID      kubelet has sufficient PID available
-  Ready                True    Thu, 04 May 2023 12:28:22 +0200   Fri, 28 Apr 2023 16:08:33 +0200   KubeletReady                 kubelet is posting ready status
-```
+2. Check if there is any pod consuming lots of CPU/Mem
+    
+    ```
+    kubectl resource-capacity -pu --sort mem.usage --node-labels node-role.kubernetes.io/control-plane=
+    
+    NODE                                          NAMESPACE          POD                                                                  CPU REQUESTS   CPU LIMITS      CPU UTIL      MEMORY REQUESTS   MEMORY LIMITS   MEMORY UTIL
+    *                                             *                  *                                                                    10401m (86%)   13042m (108%)   2830m (23%)   31137Mi (67%)     43484Mi (93%)   32059Mi (69%)
+    
+    ip-10-0-5-112.eu-central-1.compute.internal   *                  *                                                                    3585m (89%)    3807m (95%)     1349m (33%)   10609Mi (69%)     14293Mi (93%)   11348Mi (73%)
+    ip-10-0-5-112.eu-central-1.compute.internal   giantswarm         aws-admission-controller-6bb6dfb7df-z8hkg                            15m (0%)       75m (1%)        1m (0%)       100Mi (0%)        167Mi (1%)      28Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   kube-system        aws-cloud-controller-manager-w89jc                                   15m (0%)       0m (0%)         2m (0%)       100Mi (0%)        0Mi (0%)        29Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   giantswarm         aws-operator-14-15-0-54559bc49b-26xcg                                15m (0%)       37m (0%)        2m (0%)       100Mi (0%)        100Mi (0%)      61Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   monitoring         cert-exporter-daemonset-wqwnr                                        50m (1%)       150m (3%)       1m (0%)       50Mi (0%)         50Mi (0%)       15Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   kube-system        cert-manager-controller-5697745d4d-zjzzh                             50m (1%)       0m (0%)         4m (0%)       100Mi (0%)        0Mi (0%)        266Mi (1%)
+    ip-10-0-5-112.eu-central-1.compute.internal   kube-system        cilium-operator-7744d4689c-hpknn                                     0m (0%)        0m (0%)         1m (0%)       0Mi (0%)          0Mi (0%)        42Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   kube-system        cilium-zhcbh                                                         100m (2%)      0m (0%)         17m (0%)      100Mi (0%)        0Mi (0%)        298Mi (1%)
+    ip-10-0-5-112.eu-central-1.compute.internal   kube-system        coredns-workers-cff679f78-blwf4                                      250m (6%)      0m (0%)         3m (0%)       192Mi (1%)        192Mi (1%)      42Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   kube-system        ebs-csi-controller-678bcd7994-zl8pj                                  55m (1%)       0m (0%)         2m (0%)       211Mi (1%)        0Mi (0%)        138Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   giantswarm         etcd-backup-operator-b54fdc876-8dz92                                 11m (0%)       11m (0%)        5m (0%)       105Mi (0%)        269Mi (1%)      31Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   giantswarm         falco-4tsnk                                                          93m (2%)       111m (2%)       16m (0%)      121Mi (0%)        242Mi (1%)      93Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   giantswarm         falco-falco-exporter-76758                                           100m (2%)      100m (2%)       1m (0%)       128Mi (0%)        128Mi (0%)      20Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   flux-giantswarm    image-reflector-controller-b8f54fcb6-4zl79                           100m (2%)      0m (0%)         5m (0%)       100Mi (0%)        0Mi (0%)        53Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   kube-system        k8s-api-healthz-ip-10-0-5-112.eu-central-1.compute.internal          50m (1%)       0m (0%)         13m (0%)      20Mi (0%)         0Mi (0%)        13Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   kube-system        k8s-api-server-ip-10-0-5-112.eu-central-1.compute.internal           1133m (28%)    2550m (63%)     160m (4%)     7168Mi (46%)      11264Mi (73%)   4548Mi (29%)
+    ip-10-0-5-112.eu-central-1.compute.internal   giantswarm         k8s-audit-metrics-fb84d                                              23m (0%)       23m (0%)        11m (0%)      105Mi (0%)        105Mi (0%)      34Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   kube-system        k8s-controller-manager-ip-10-0-5-112.eu-central-1.compute.internal   200m (5%)      0m (0%)         23m (0%)      200Mi (1%)        0Mi (0%)        588Mi (3%)
+    ip-10-0-5-112.eu-central-1.compute.internal   kube-system        k8s-scheduler-ip-10-0-5-112.eu-central-1.compute.internal            200m (5%)      0m (0%)         2m (0%)       200Mi (1%)        0Mi (0%)        76Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   kyverno            kyverno-56b45576df-ddx8q                                             100m (2%)      100m (2%)       726m (18%)    256Mi (1%)        1024Mi (6%)     558Mi (3%)
+    ip-10-0-5-112.eu-central-1.compute.internal   giantswarm         management-cluster-admission-controller-manager-f4df9d976-rbp4n      100m (2%)      250m (6%)       1m (0%)       250Mi (1%)        250Mi (1%)      25Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   monitoring         net-exporter-z6ng4                                                   50m (1%)       0m (0%)         1m (0%)       75Mi (0%)         150Mi (0%)      16Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   kube-system        ingress-nginx-controller-app-546758487d-jqgrc                        500m (12%)     0m (0%)         2m (0%)       600Mi (3%)        0Mi (0%)        211Mi (1%)
+    ip-10-0-5-112.eu-central-1.compute.internal   monitoring         node-exporter-z2qgt                                                  75m (1%)       0m (0%)         1m (0%)       50Mi (0%)         75Mi (0%)       26Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   monitoring         oauth2-proxy-55568fc5cc-h85d6                                        100m (2%)      100m (2%)       1m (0%)       100Mi (0%)        100Mi (0%)      23Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   promtail           promtail-454w6                                                       100m (2%)      200m (5%)       13m (0%)      128Mi (0%)        128Mi (0%)      87Mi (0%)
+    ip-10-0-5-112.eu-central-1.compute.internal   giantswarm         vault-exporter-6c64bbc55d-zd7km                                      100m (2%)      100m (2%)       1m (0%)       50Mi (0%)         50Mi (0%)       23Mi (0%)
+    ```
+    
+    You can install the above tool with krew or check [here](https://github.com/robscott/kube-capacity):
+    ```
+    kubectl krew install resource-capacity
+    ```
 
-There you can see if network, memory or disk could be behind the problem.
+3. Check `K8s API performance` grafana dashboard on teh installation to verify the ETCD and node pressure if correct
 
-2) Check if there is any pod consuming lots of CPU/Mem
-
-```
-kubectl resource-capacity -pu --sort mem.usage --node-labels node-role.kubernetes.io/control-plane=
-
-NODE                                          NAMESPACE          POD                                                                  CPU REQUESTS   CPU LIMITS      CPU UTIL      MEMORY REQUESTS   MEMORY LIMITS   MEMORY UTIL
-*                                             *                  *                                                                    10401m (86%)   13042m (108%)   2830m (23%)   31137Mi (67%)     43484Mi (93%)   32059Mi (69%)
-
-ip-10-0-5-112.eu-central-1.compute.internal   *                  *                                                                    3585m (89%)    3807m (95%)     1349m (33%)   10609Mi (69%)     14293Mi (93%)   11348Mi (73%)
-ip-10-0-5-112.eu-central-1.compute.internal   giantswarm         aws-admission-controller-6bb6dfb7df-z8hkg                            15m (0%)       75m (1%)        1m (0%)       100Mi (0%)        167Mi (1%)      28Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   kube-system        aws-cloud-controller-manager-w89jc                                   15m (0%)       0m (0%)         2m (0%)       100Mi (0%)        0Mi (0%)        29Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   giantswarm         aws-operator-14-15-0-54559bc49b-26xcg                                15m (0%)       37m (0%)        2m (0%)       100Mi (0%)        100Mi (0%)      61Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   monitoring         cert-exporter-daemonset-wqwnr                                        50m (1%)       150m (3%)       1m (0%)       50Mi (0%)         50Mi (0%)       15Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   kube-system        cert-manager-controller-5697745d4d-zjzzh                             50m (1%)       0m (0%)         4m (0%)       100Mi (0%)        0Mi (0%)        266Mi (1%)
-ip-10-0-5-112.eu-central-1.compute.internal   kube-system        cilium-operator-7744d4689c-hpknn                                     0m (0%)        0m (0%)         1m (0%)       0Mi (0%)          0Mi (0%)        42Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   kube-system        cilium-zhcbh                                                         100m (2%)      0m (0%)         17m (0%)      100Mi (0%)        0Mi (0%)        298Mi (1%)
-ip-10-0-5-112.eu-central-1.compute.internal   kube-system        coredns-workers-cff679f78-blwf4                                      250m (6%)      0m (0%)         3m (0%)       192Mi (1%)        192Mi (1%)      42Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   kube-system        ebs-csi-controller-678bcd7994-zl8pj                                  55m (1%)       0m (0%)         2m (0%)       211Mi (1%)        0Mi (0%)        138Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   giantswarm         etcd-backup-operator-b54fdc876-8dz92                                 11m (0%)       11m (0%)        5m (0%)       105Mi (0%)        269Mi (1%)      31Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   giantswarm         falco-4tsnk                                                          93m (2%)       111m (2%)       16m (0%)      121Mi (0%)        242Mi (1%)      93Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   giantswarm         falco-falco-exporter-76758                                           100m (2%)      100m (2%)       1m (0%)       128Mi (0%)        128Mi (0%)      20Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   flux-giantswarm    image-reflector-controller-b8f54fcb6-4zl79                           100m (2%)      0m (0%)         5m (0%)       100Mi (0%)        0Mi (0%)        53Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   kube-system        k8s-api-healthz-ip-10-0-5-112.eu-central-1.compute.internal          50m (1%)       0m (0%)         13m (0%)      20Mi (0%)         0Mi (0%)        13Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   kube-system        k8s-api-server-ip-10-0-5-112.eu-central-1.compute.internal           1133m (28%)    2550m (63%)     160m (4%)     7168Mi (46%)      11264Mi (73%)   4548Mi (29%)
-ip-10-0-5-112.eu-central-1.compute.internal   giantswarm         k8s-audit-metrics-fb84d                                              23m (0%)       23m (0%)        11m (0%)      105Mi (0%)        105Mi (0%)      34Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   kube-system        k8s-controller-manager-ip-10-0-5-112.eu-central-1.compute.internal   200m (5%)      0m (0%)         23m (0%)      200Mi (1%)        0Mi (0%)        588Mi (3%)
-ip-10-0-5-112.eu-central-1.compute.internal   kube-system        k8s-scheduler-ip-10-0-5-112.eu-central-1.compute.internal            200m (5%)      0m (0%)         2m (0%)       200Mi (1%)        0Mi (0%)        76Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   kyverno            kyverno-56b45576df-ddx8q                                             100m (2%)      100m (2%)       726m (18%)    256Mi (1%)        1024Mi (6%)     558Mi (3%)
-ip-10-0-5-112.eu-central-1.compute.internal   giantswarm         management-cluster-admission-controller-manager-f4df9d976-rbp4n      100m (2%)      250m (6%)       1m (0%)       250Mi (1%)        250Mi (1%)      25Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   monitoring         net-exporter-z6ng4                                                   50m (1%)       0m (0%)         1m (0%)       75Mi (0%)         150Mi (0%)      16Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   kube-system        ingress-nginx-controller-app-546758487d-jqgrc                        500m (12%)     0m (0%)         2m (0%)       600Mi (3%)        0Mi (0%)        211Mi (1%)
-ip-10-0-5-112.eu-central-1.compute.internal   monitoring         node-exporter-z2qgt                                                  75m (1%)       0m (0%)         1m (0%)       50Mi (0%)         75Mi (0%)       26Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   monitoring         oauth2-proxy-55568fc5cc-h85d6                                        100m (2%)      100m (2%)       1m (0%)       100Mi (0%)        100Mi (0%)      23Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   promtail           promtail-454w6                                                       100m (2%)      200m (5%)       13m (0%)      128Mi (0%)        128Mi (0%)      87Mi (0%)
-ip-10-0-5-112.eu-central-1.compute.internal   giantswarm         vault-exporter-6c64bbc55d-zd7km                                      100m (2%)      100m (2%)       1m (0%)       50Mi (0%)         50Mi (0%)       23Mi (0%)
-```
-
-You can install the above tool with krew or check [here](https://github.com/robscott/kube-capacity):
-```
-kubectl krew install resource-capacity
-```
-
-2) Check `K8s API performance` grafana dashboard on teh installation to verify the ETCD and node pressure if correct
-
-```
-» export=INSTALLATION=XXXXX
-» opsctl open -i $INSTALLATION -a grafana
-```
-
-__Note__: If you notice the CPU and memory overloads the machine for last days, you can think on growing the master machine to next instance type.
+    ```
+    » export=INSTALLATION=XXXXX
+    » opsctl open -i $INSTALLATION -a grafana
+    ```
+    
+    __Note__: If you notice the CPU and memory overloads the machine for last days, you can think on growing the master machine to next instance type.

--- a/content/docs/support-and-ops/ops-recipes/troubleshooting-gitops.md
+++ b/content/docs/support-and-ops/ops-recipes/troubleshooting-gitops.md
@@ -9,42 +9,42 @@ We are offering GitOps as interface for our customers, here we collect tips on h
 
 # Table of Contents
 1. [Identify which kustomization owns a resource](#identify-which-kustomization-owns-a-resource)
-2. [Download the Git Repository source](#Download-the-Git-Repository-source)
-3. [Stop GitOps reconciliation](#Stop-GitOps-reconciliation)
+2. [Download the Git Repository source](#download-the-git-repository-source)
+3. [Stop GitOps reconciliation](#stop-gitops-reconciliation)
 
 
 ## Identify which kustomization owns a resource
 
-1) A resource contains a set of labels that identify which kustomization it belongs to. Example:
+1. resource contains a set of labels that identify which kustomization it belongs to. Example:
 
-```
-  labels:
+    ```
+      labels:
+        ...
+        kustomize.toolkit.fluxcd.io/name: gorilla-clusters-rfjh2
+        kustomize.toolkit.fluxcd.io/namespace: default
+    ```
+    
+    From the kustomization one can tell the source Git repository by looking at the spec field `sourceRef`.
+
+2. Use the flux command line. It offers a subcommand `trace` which describes all details related to GitOps:
+
+    ```
+    » flux trace app/alfred-app -n alfred-ns
+    
+    Object:        App/alfred-app
+    Namespace:     rfjh2
+    Status:        Managed by Flux
+    ---
+    Kustomization: gorilla-clusters-rfjh2
+    Namespace:     default
     ...
-    kustomize.toolkit.fluxcd.io/name: gorilla-clusters-rfjh2
-    kustomize.toolkit.fluxcd.io/namespace: default
-```
-
-From the kustomization one can tell the source Git repository by looking at the spec field `sourceRef`.
-
-2) Use the flux command line. It offers a subcommand `trace` which describes all details related to GitOps:
-
-```
-» flux trace app/alfred-app -n alfred-ns
-
-Object:        App/alfred-app
-Namespace:     rfjh2
-Status:        Managed by Flux
----
-Kustomization: gorilla-clusters-rfjh2
-Namespace:     default
-...
----
-GitRepository: workload-clusters-fleet
-Namespace:     default
-...
-```
-
-__Note__: If the resource has no labels (or `flux trace` returns `object not managed by Flux`) the object is not produced as result of helm or kustomize but could still be owned by a higher resource. An example would be a *pod* which may not have the labels, but the parent *deployment* does.
+    ---
+    GitRepository: workload-clusters-fleet
+    Namespace:     default
+    ...
+    ```
+    
+    __Note__: If the resource has no labels (or `flux trace` returns `object not managed by Flux`) the object is not produced as result of helm or kustomize but could still be owned by a higher resource. An example would be a *pod* which may not have the labels, but the parent *deployment* does.
 
 ## Download the Git Repository source
 


### PR DESCRIPTION
Towards giantswarm/giantswarm#28072

### Summary

Replace GitHub Action `gaurav-nelson/github-action-markdown-link-check` to avoid spawning too many Node instances.

The problem is referenced in the project's README:
![grafik](https://github.com/giantswarm/handbook/assets/18163495/eb5ac0bc-3671-4138-bd72-a8efd7d9d914)

This PR changes this and just calls `markdown-link-check` directly, in an efficient way.

Same approach as: giantswarm/giantswarm#28072