### PR TITLE
Update docsy to v0.9.0, improve TOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update docsy to v0.9.0
+
 ## [0.13.0] - 2024-02-16
 
 ## [0.12.0] - 2024-02-16

--- a/layouts/partials/taxonomy_terms_clouds.html
+++ b/layouts/partials/taxonomy_terms_clouds.html
@@ -1,0 +1,3 @@
+<!-- Empty placeholder to override and disable the docsy theme's taxonomy cloud in the right sidebar.
+Also see: https://github.com/google/docsy/issues/704
+-->


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29870
Mirrors https://github.com/giantswarm/giantswarm/pull/29908

### Summary

Also update docsy theme to v0.9.0 here.

### Note

Table of contents (TOC) rendering is now correctly suppressed when it is empty (no headings) for a page.
