### PR TITLE
Only render TOC when not empty

### DIFF
--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,8 +1,8 @@
-{{ if .Page.TableOfContents }}
+{{ if and (ne .Params.toc false) (gt (len .Page.TableOfContents) 33) }}
 <hr>
 <aside>
     <header>
-    <h3>Table of content</h3>
+    <h3>Table of contents</h3>
     </header>
     {{ .TableOfContents }}
 </aside>


### PR DESCRIPTION
### Summary

Only render table of contents (TOC) when not empty.

### Note

There's currently no better way to check for an empty TOC than measuring its length, as the basic `<nav>` element is always contained.