### PR TITLE
Fix vintage platform docs links

### DIFF
--- a/content/docs/dev-and-releng/app-developer-processes/app_bundles.md
+++ b/content/docs/dev-and-releng/app-developer-processes/app_bundles.md
@@ -13,7 +13,7 @@ way to represent a group of apps as a single app, to the user and to the system.
 The App Bundle usage is currently well established in the company.
 
 For example, for CAPI it has been decided to deploy default apps in this way, see [ADR](https://intranet.giantswarm.io/docs/product/architecture-specs-adrs/adr/016-capi-releases/). By bundling a group of default apps we make the installation
-simpler and also means we can retire the [Release](https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io/) CRD used in vintage clusters. Hence, a `default-apps-PROVIDER` app bundle will
+simpler and also means we can retire the [Release](https://docs.giantswarm.io/vintage/use-the-api/management-api/crd/releases.release.giantswarm.io/) CRD used in vintage clusters. Hence, a `default-apps-PROVIDER` app bundle will
 exist for each CAPI provider.
 
 Another example is grouping apps by the topic, creating specialized bundles, like for example the `security-pack` app.

--- a/content/docs/dev-and-releng/app-developer-processes/creating_app_catalog.md
+++ b/content/docs/dev-and-releng/app-developer-processes/creating_app_catalog.md
@@ -27,7 +27,7 @@ The pipeline is responsible for building the Helm chart and including it in the 
 
 Please start by reading [documentation about app catalogs and apps](https://github.com/giantswarm/giantswarm/blob/main/archive/archive-roadmap/MANAGED-SERVICES-CATALOG.MD).
 
-All application catalogs are defined in the management cluster using the [Catalog](https://docs.giantswarm.io/use-the-api/management-api/crd/catalogs.application.giantswarm.io/) CRD. To deploy the Catalog CRs,
+All application catalogs are defined in the management cluster using the [Catalog](https://docs.giantswarm.io/vintage/use-the-api/management-api/crd/catalogs.application.giantswarm.io/) CRD. To deploy the Catalog CRs,
 the following process is used:
 
 - App catalog configuration file needs to be added to the [`giantswarm/installations`](https://github.com/giantswarm/installations)

--- a/content/docs/product/docs/_index.md
+++ b/content/docs/product/docs/_index.md
@@ -18,7 +18,7 @@ Our goal is to have all documentation for our product be available via that site
 
 Our responsibilities for public documentation are layered.
 
-- Ownership for content is assigned **according to team or SIG responsibilities**. For example, Team Horizon "owns" articles related to [Developer Platform Overview](https://github.com/giantswarm/docs/blob/main/src/content/platform-overview/_index.md) as you can see on the front matter (defined by the YAML header fields).
+- Ownership for content is assigned **according to team or SIG responsibilities**. For example, Team Horizon "owns" articles related to [Developer Platform Overview](https://github.com/giantswarm/docs/blob/main/src/content/vintage/platform-overview/_index.md) as you can see on the front matter (defined by the YAML header fields).
 
 - SIG Docs is responsible for overall content coherence and consistency.
 


### PR DESCRIPTION
### Summary

Fix a few broken links.

The cause is a malfunctioning redirect, but let's use the correct links in any case.
