### PR TITLE
Dockerfile: use nginx from gsoci.azurecr.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN find /src/public \
   -delete
 
 # use minimal nginx alpine image for serving static html
-FROM quay.io/giantswarm/nginx-unprivileged:1.25-alpine
+FROM gsoci.azurecr.io/giantswarm/nginx-unprivileged:1.25-alpine
 EXPOSE 8080
 USER 0
 

--- a/proxy/Dockerfile.handbook-proxy
+++ b/proxy/Dockerfile.handbook-proxy
@@ -1,5 +1,5 @@
 # use minimal nginx alpine image for proxying to hugo and decap-cms containers
-FROM quay.io/giantswarm/nginx-unprivileged:1.25-alpine
+FROM gsoci.azurecr.io/giantswarm/nginx-unprivileged:1.25-alpine
 EXPOSE 8081
 USER 0
 


### PR DESCRIPTION
### Summary

Use the `nginx-unprivileged:1.25-alpine` from the `gsoci.azurecr.io` image registry.
