### PR TITLE
Fix link to registries docs, remove name Quay.io

### DIFF
--- a/content/docs/dev-and-releng/repository/app/_index.md
+++ b/content/docs/dev-and-releng/repository/app/_index.md
@@ -83,7 +83,7 @@ To maintain team ownership and keep the repository up-to-date with our standards
 
 ## Step 6 - Create a container repo
 
-To host container images based on the new repository, [set up a Quay.io repository](https://intranet.giantswarm.io/docs/dev-and-releng/container-registry/) for it.
+To host container images based on the new repository, [set up registry repositories](https://intranet.giantswarm.io/docs/dev-and-releng/container-registry/) for it.
 
 ## Step 7 - Final touches
 

--- a/content/docs/dev-and-releng/repository/go/_index.md
+++ b/content/docs/dev-and-releng/repository/go/_index.md
@@ -89,7 +89,7 @@ To maintain team ownership and keep the repository up-to-date with our standards
 
 ## Step 7 - Create a container repo
 
-To build containers for the new repository, [set up a Quay.io repository](https://intranet.giantswarm.io/docs/dev-and-releng/container-registry/) for it.
+To build containers for the new repository, [set up registry repositories](https://intranet.giantswarm.io/docs/dev-and-releng/container-registry/) for it.
 
 ## Step 8 - Final touches
 


### PR DESCRIPTION
This updates an outdated wording, as our registries are not mainly about Quay.