### PR TITLE
ci config: migrate to app-build-suite

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -1,0 +1,5 @@
+generate-metadata: true
+chart-dir: ./helm/handbook
+destination: ./build
+catalog-base-url: https://giantswarm.github.io/giantswarm-operations-platform-catalog/
+replace-chart-version-with-git: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
     - architect/push-to-app-catalog:
         context: architect
         name: push-to-app-catalog
-        executor: architect
+        executor: app-build-suite
         app_catalog: giantswarm-operations-platform-catalog
         app_catalog_test: giantswarm-operations-platform-test-catalog
         chart: handbook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lower resource requests and limits, make them configurable
 - Change front-matter field `confidentiality` to `classification` to align with ISMS
 - Fix ISMS links in remote-work-checklist page
-- Minor corrections in code signing howto 
+- Minor corrections in code signing howto
+- Migrate to `app-build-suite`
 
 ## [0.13.0] - 2024-02-16
 

--- a/helm/handbook/Chart.yaml
+++ b/helm/handbook/Chart.yaml
@@ -3,9 +3,10 @@ appVersion: main
 description: A Helm chart for out handbook
 engine: gotpl
 home: https://github.com/giantswarm/handbook
+icon: https://s.giantswarm.io/app-icons/handbook/1/dark.svg
 name: handbook
 annotations:
-  application.giantswarm.io/team: team
+  application.giantswarm.io/team: up
 sources:
   - https://github.com/giantswarm/handbook
-version: [[ .Version ]]
+version: 0.13.82-dev


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/31101#issuecomment-2470434482

### Summary

Migrate Handbook to use `app-build-suite`, according to:
https://intranet.giantswarm.io/docs/dev-and-releng/app-build-suite/migration/

### Dependencies

- https://github.com/giantswarm/web-assets/pull/252