### PR TITLE
Add `kubectl debug` info in Troubleshooting recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New recipe for Kyverno stuck in upgrade pending.
 - MC types to glossary (ephemeral and stable-testing)
+- Added `kubectl debug` info in Troubleshooting recipe
 
 ### Changed
 

--- a/content/docs/support-and-ops/ops-recipes/troubleshooting-in-general.md
+++ b/content/docs/support-and-ops/ops-recipes/troubleshooting-in-general.md
@@ -84,4 +84,4 @@ Then you can run your debug container like so:
 kubectl debug -n loki loki-backend-0 -it --image alpine --custom customspec.yaml -- /bin/sh
 ```
 
-Feel free to chose your debug image, so you have the tools you need.
+Feel free to choose your debug image, so you have the tools you need.

--- a/content/docs/support-and-ops/ops-recipes/troubleshooting-in-general.md
+++ b/content/docs/support-and-ops/ops-recipes/troubleshooting-in-general.md
@@ -38,13 +38,14 @@ As an alternative to the `kgs` command, you can also install the debug toolbox v
 helm template debug ./helm/debug-toolbox --values=/<custom_values>/values.yaml
 ```
 
-## Kubectl debug
+## `kubectl debug`
 
 `kubectl debug` helps debugging cluster resources using interactive debugging containers.
 
-The problem is by default these containers are not very secure, and get denied by our cluster security policies as shown here:
+By default these containers are not very secure and therefore get denied by our cluster security policies as shown here:
+
 ```
-$ kubectl debug -n loki loki-backend-0 --image alpine -- /bin/sh
+$ kubectl debug --namespace loki loki-backend-0 --image alpine -- /bin/sh
 Defaulting debug container name to debugger-9fp9k.
 Error from server: admission webhook "validate.kyverno.svc-fail" denied the request: 
 
@@ -59,11 +60,12 @@ disallow-privilege-escalation:
     be set to `false`. rule privilege-escalation failed at path /spec/ephemeralContainers/0/securityContext/'
 ```
 
-### Setting custom securityContext with kubectl debug
+### Setting custom container security context with `kubectl debug`
 
-⚠️This requires at least `kubectl`v1.31
+⚠️ This requires at least `kubectl` v1.31.
 
-You should create a yaml file with your securityContext. We should call it `customspec.yaml`:
+First we create a YAML file with a secure container `securityContext` called `custom-spec.yaml` in this example:
+
 ```yaml
 securityContext:
   fsGroup: 10001
@@ -79,9 +81,10 @@ securityContext:
     type: RuntimeDefault
 ```
 
-Then you can run your debug container like so:
+Then we can run our debug container like this:
+
 ```
-kubectl debug -n loki loki-backend-0 -it --image alpine --custom customspec.yaml -- /bin/sh
+kubectl debug --namespace loki loki-backend-0 --stdin --tty --image alpine --custom customspec.yaml -- /bin/sh
 ```
 
-Feel free to choose your debug image, so you have the tools you need.
+Feel free to choose your own debug image, so you have the tools you need.


### PR DESCRIPTION
### What does this PR do?

Share info on how to run `kubectl debug` on our clusters, useful to debug pods that don't have the commands we need.

### What is needed from the reviewers?

Please check:
- there's enough context to understand
- this is the right place to put this info
- my English language is ok
- it's technically ok (I guess if you can reproduce it following the procedure it's good!)

### Why is this piece of content here?

I followed https://intranet.giantswarm.io/docs/decision-processes/doc-location/
And:
- this is mostly for GS people
- but there's no sensitive info here
- and it could benefit people outside of the company