### PR TITLE
fully configure nginx, support RO filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New recipe for Kyverno stuck in upgrade pending.
 - MC types to glossary (ephemeral and stable-testing)
 - Added `kubectl debug` info in Troubleshooting recipe
+- Improve nginx configuration
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,14 @@ FROM gsoci.azurecr.io/giantswarm/nginx-unprivileged:1.27-alpine
 EXPOSE 8080
 USER 0
 
-# The custom config disables absolute redirects and enables gzip compression
-COPY proxy/proxy-production.default.conf /etc/nginx/conf.d/default.conf
+# Delete default config (which we have no control over)
+RUN rm -r /etc/nginx/conf.d && rm /etc/nginx/nginx.conf
+
+# The custom config enables the /searchapi route, proxying to sitesearch-app.docs:9200
+COPY proxy/proxy-production.default.conf /etc/nginx/nginx.conf
+
+# Ensure tmp dir exists and has right ownership
+RUN mkdir -p /tmp/nginx && chown -R 101 /tmp/nginx
 
 # copy in staticly built hugo site from build step above
 COPY --from=build-production /src/public /usr/share/nginx/html

--- a/helm/handbook/templates/handbook-deployment.yaml
+++ b/helm/handbook/templates/handbook-deployment.yaml
@@ -55,8 +55,8 @@ spec:
               memory: {{ .Values.resources.handbook.limits.memory }}
 
           volumeMounts:
-            - mountPath: /var/cache/nginx
-              name: cache-volume
+            - mountPath: /tmp/nginx
+              name: nginx-tmp
           livenessProbe:
             httpGet:
               path: /
@@ -66,7 +66,7 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 2
       volumes:
-        - name: cache-volume
+        - name: nginx-tmp
           emptyDir: {}
       serviceAccount: handbook
       serviceAccountName: handbook

--- a/proxy/Dockerfile.handbook-proxy
+++ b/proxy/Dockerfile.handbook-proxy
@@ -3,8 +3,14 @@ FROM gsoci.azurecr.io/giantswarm/nginx-unprivileged:1.27-alpine
 EXPOSE 8081
 USER 0
 
+# Delete default config (which we have no control over)
+RUN rm -r /etc/nginx/conf.d && rm /etc/nginx/nginx.conf
+
 # configure CMS redirect /admin /auth /callback -> decap, / -> hugo
-COPY proxy-cms-admin.conf /etc/nginx/conf.d/proxy-cms-admin.conf
+COPY proxy-cms-admin.conf /etc/nginx/nginx.conf
+
+# Ensure tmp dir exists and has right ownership
+RUN mkdir -p /tmp/nginx && chown -R 101 /tmp/nginx
 
 # copy in staticly built hugo site from build step above
 #VOLUME /usr/share/nginx/html

--- a/proxy/proxy-cms-admin-dev.conf
+++ b/proxy/proxy-cms-admin-dev.conf
@@ -20,47 +20,79 @@
 #     - run: yarn dev
 #   4. visit http://localhost:8081/admin/
 #
-server {
-    listen 8081 default_server;
-    server_name _;
-    access_log /dev/stderr combined;
-    error_log /dev/stderr warn;
+pid /tmp/nginx/pid;
 
-    # let hugo handle requests by default
-    # (a possible webhook for updates also goes here)
-    location / {
-        proxy_pass https://handbook.giantswarm.io;
-        proxy_pass_request_headers      on;
-        proxy_set_header   X-Real-IP        $remote_addr;
-        proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
-        proxy_set_header Early-Data $ssl_early_data;
-    }
+error_log /dev/stdout warn;
 
-    # proxy /admin, /auth and /callback to the docker-decap-cms-standalone container
-    location /admin/ {
-        proxy_pass http://host.containers.internal:8080/;   # target: static-cms dev server (live reload), modify for docker
-        proxy_pass_request_headers      on;
-        proxy_set_header   Host        localhost:8081;
-        proxy_set_header   X-Real-IP        $remote_addr;
-        proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
-        proxy_set_header Early-Data $ssl_early_data;
-    }
+worker_processes 1;
 
-    location /auth {
-        proxy_pass http://host.containers.internal:8082;
-        proxy_pass_request_headers      on;
-        #proxy_set_header   Host        localhost:8081;
-        proxy_set_header   X-Real-IP        $remote_addr;
-        proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
-        proxy_set_header Early-Data $ssl_early_data;
-    }
+events {
+  worker_connections 1024;
+}
 
-    location /callback {
-        proxy_pass http://host.containers.internal:8082;
-        proxy_pass_request_headers      on;
-        #proxy_set_header   Host        localhost:8081;
-        proxy_set_header   X-Real-IP        $remote_addr;
-        proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
-        proxy_set_header Early-Data $ssl_early_data;
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    open_file_cache max=1000 inactive=60s;
+    open_file_cache_valid 30s;
+    open_file_cache_min_uses 2;
+    open_file_cache_errors on;
+    sendfile on;
+    server_tokens off;
+    log_format custom '"$request" '
+                        's=$status b=$body_bytes_sent t=$request_time '
+                        '"$http_x_forwarded_for" '
+                        '"$http_user_agent" "$http_referer"';
+
+    # running as non-root requires a writeable path
+    client_body_temp_path /tmp/nginx/client_temp;
+    proxy_temp_path       /tmp/nginx/proxy_temp;
+    fastcgi_temp_path     /tmp/nginx/fastcgi_temp;
+    uwsgi_temp_path       /tmp/nginx/uwsgi_temp;
+    scgi_temp_path        /tmp/nginx/scgi_temp;
+
+    server {
+        listen 8081 default_server;
+        server_name _;
+        access_log /dev/stderr combined;
+        error_log /dev/stderr warn;
+
+        # let hugo handle requests by default
+        # (a possible webhook for updates also goes here)
+        location / {
+            proxy_pass https://handbook.giantswarm.io;
+            proxy_pass_request_headers      on;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header Early-Data $ssl_early_data;
+        }
+
+        # proxy /admin, /auth and /callback to the docker-decap-cms-standalone container
+        location /admin/ {
+            proxy_pass http://host.containers.internal:8080/;   # target: static-cms dev server (live reload), modify for docker
+            proxy_pass_request_headers      on;
+            proxy_set_header   Host        localhost:8081;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header Early-Data $ssl_early_data;
+        }
+
+        location /auth {
+            proxy_pass http://host.containers.internal:8082;
+            proxy_pass_request_headers      on;
+            #proxy_set_header   Host        localhost:8081;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header Early-Data $ssl_early_data;
+        }
+
+        location /callback {
+            proxy_pass http://host.containers.internal:8082;
+            proxy_pass_request_headers      on;
+            #proxy_set_header   Host        localhost:8081;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header Early-Data $ssl_early_data;
+        }
     }
 }

--- a/proxy/proxy-cms-admin.conf
+++ b/proxy/proxy-cms-admin.conf
@@ -1,51 +1,82 @@
-# NGINX configuration
-server {
-    listen 8081 default_server;
-    server_name _;
-    access_log /dev/stderr combined;
-    error_log /dev/stderr warn;
+pid /tmp/nginx/pid;
 
-    # let hugo handle requests by default
-    # (a possible webhook for updates also goes here)
-    location / {
-        proxy_pass http://hugo:1313;
-        proxy_pass_request_headers      on;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Real-IP        $remote_addr;
-        proxy_set_header X-Forwarded-For  $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Port $server_port;
-        proxy_set_header X-Frame-Options SAMEORIGIN;
-        proxy_set_header Early-Data $ssl_early_data;
+error_log /dev/stdout warn;
 
-        # websocket support for live reload
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-    }
+worker_processes 1;
 
-    # proxy /admin, /auth and /callback to the docker-decap-cms-standalone container
-    location /admin/ {
-        proxy_pass http://static-cms:8080/;
-        proxy_pass_request_headers      on;
-        proxy_set_header   X-Real-IP        $remote_addr;
-        proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
-        proxy_set_header Early-Data $ssl_early_data;
-    }
+events {
+  worker_connections 1024;
+}
 
-    location /auth {
-        proxy_pass http://static-cms:8080;
-        proxy_pass_request_headers      on;
-        proxy_set_header   X-Real-IP        $remote_addr;
-        proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
-        proxy_set_header Early-Data $ssl_early_data;
-    }
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    open_file_cache max=1000 inactive=60s;
+    open_file_cache_valid 30s;
+    open_file_cache_min_uses 2;
+    open_file_cache_errors on;
+    sendfile on;
+    server_tokens off;
+    log_format custom '"$request" '
+                        's=$status b=$body_bytes_sent t=$request_time '
+                        '"$http_x_forwarded_for" '
+                        '"$http_user_agent" "$http_referer"';
 
-    location /callback {
-        proxy_pass http://static-cms:8080;
-        proxy_pass_request_headers      on;
-        proxy_set_header   X-Real-IP        $remote_addr;
-        proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
-        proxy_set_header Early-Data $ssl_early_data;
+    # running as non-root requires a writeable path
+    client_body_temp_path /tmp/nginx/client_temp;
+    proxy_temp_path       /tmp/nginx/proxy_temp;
+    fastcgi_temp_path     /tmp/nginx/fastcgi_temp;
+    uwsgi_temp_path       /tmp/nginx/uwsgi_temp;
+    scgi_temp_path        /tmp/nginx/scgi_temp;
+
+    server {
+        listen 8081 default_server;
+        server_name _;
+        access_log /dev/stderr combined;
+        error_log /dev/stderr warn;
+
+        # let hugo handle requests by default
+        # (a possible webhook for updates also goes here)
+        location / {
+            proxy_pass http://hugo:1313;
+            proxy_pass_request_headers      on;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP        $remote_addr;
+            proxy_set_header X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Port $server_port;
+            proxy_set_header X-Frame-Options SAMEORIGIN;
+            proxy_set_header Early-Data $ssl_early_data;
+
+            # websocket support for live reload
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+        }
+
+        # proxy /admin, /auth and /callback to the docker-decap-cms-standalone container
+        location /admin/ {
+            proxy_pass http://static-cms:8080/;
+            proxy_pass_request_headers      on;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header Early-Data $ssl_early_data;
+        }
+
+        location /auth {
+            proxy_pass http://static-cms:8080;
+            proxy_pass_request_headers      on;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header Early-Data $ssl_early_data;
+        }
+
+        location /callback {
+            proxy_pass http://static-cms:8080;
+            proxy_pass_request_headers      on;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header Early-Data $ssl_early_data;
+        }
     }
 }

--- a/proxy/proxy-production.default.conf
+++ b/proxy/proxy-production.default.conf
@@ -1,54 +1,56 @@
-server {
-    listen       8080;
-    server_name  localhost;
+pid /tmp/nginx/pid;
 
-    #access_log  /var/log/nginx/host.access.log  main;
+error_log /dev/stdout warn;
 
-    location / {
-        # enable relative 301 redirects to fix invalid redirects on missing trailing slash
-        # (a downstream server doesn't necessarily know the public name and port)
-        absolute_redirect off;
+worker_processes 1;
 
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
+events {
+  worker_connections 1024;
+}
 
-        # We only store compressed HTML in this directory
-        # so the index directive cannot be used.
-        rewrite     ^(.*)/$ $1/index.html last;
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    open_file_cache max=1000 inactive=60s;
+    open_file_cache_valid 30s;
+    open_file_cache_min_uses 2;
+    open_file_cache_errors on;
+    sendfile on;
+    server_tokens off;
+    log_format custom '"$request" '
+                        's=$status b=$body_bytes_sent t=$request_time '
+                        '"$http_x_forwarded_for" '
+                        '"$http_user_agent" "$http_referer"';
 
-        gzip_static always;
-        gunzip      on;
+    # running as non-root requires a writeable path
+    client_body_temp_path /tmp/nginx/client_temp;
+    proxy_temp_path       /tmp/nginx/proxy_temp;
+    fastcgi_temp_path     /tmp/nginx/fastcgi_temp;
+    uwsgi_temp_path       /tmp/nginx/uwsgi_temp;
+    scgi_temp_path        /tmp/nginx/scgi_temp;
+
+    server {
+        listen       8080;
+        server_name  localhost;
+
+        #access_log  /var/log/nginx/host.access.log  main;
+
+        location / {
+            absolute_redirect off;
+            root   /usr/share/nginx/html;
+            # We only store compressed HTML in this directory
+            # so the index directive cannot be used.
+            rewrite     ^(.*)/$ $1/index.html last;
+
+            gzip_static always;
+            gunzip      on;
+        }
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
     }
-
-    #error_page  404              /404.html;
-
-    # redirect server error pages to the static page /50x.html
-    #
-    error_page   500 502 503 504  /50x.html;
-    location = /50x.html {
-        root   /usr/share/nginx/html;
-    }
-
-    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
-    #
-    #location ~ \.php$ {
-    #    proxy_pass   http://127.0.0.1;
-    #}
-
-    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
-    #
-    #location ~ \.php$ {
-    #    root           html;
-    #    fastcgi_pass   127.0.0.1:9000;
-    #    fastcgi_index  index.php;
-    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
-    #    include        fastcgi_params;
-    #}
-
-    # deny access to .htaccess files, if Apache's document root
-    # concurs with nginx's one
-    #
-    #location ~ /\.ht {
-    #    deny  all;
-    #}
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/31101#issuecomment-2470437117
Problem triggered by https://github.com/giantswarm/handbook/pull/295 

Slack thread with the down alert: https://gigantic.slack.com/archives/C90BZMUJ1/p1733124575839329

### Summary

The Handbook image stopped working in the updated chart (due to RO filesystem).

This seems like a limitation of the upstream image's default configuration.

Like for our Intranet image, supplying a complete and sensible nginx configuration and pre-creating the needed directories (in a mounted empty-dir) should solve this.