### PR TITLE
emergency availability: link checker exception

### DIFF
--- a/.github/workflows/markdown-link-check.json
+++ b/.github/workflows/markdown-link-check.json
@@ -71,6 +71,15 @@
     },
     {
       "pattern": "https://docs.google.com/spreadsheets/d/"
+    },
+    {
+      "pattern": "https://giant-swarm.personio.de/staff"
+    },
+    {
+      "pattern": "https://docs.google.com/document/d/1Ws05-gb5SESuwaAKI9gQipGmPjUoVxs_KZqEREjZcVk"
+    },
+    {
+      "pattern": "https://giantswarm.app.opsgenie.com/alert/list"
     }
   ]
 }

--- a/content/docs/people/p32/emergency-availablity.md
+++ b/content/docs/people/p32/emergency-availablity.md
@@ -14,10 +14,10 @@ This has been established in the [first ground rules](https://docs.google.com/do
 
 # Reaching Engineers
 
-Engineers are available through [opsgenie](https://giantswarm.app.opsgenie.com/alert/list).
-Reaching out can easily done by creating an `alert` through the opsgenie UI and assigning the person you need to contact.
+Engineers are available through [Opsgenie](https://giantswarm.app.opsgenie.com/alert/list).
+Reaching out can easily be done by creating an `alert` through the Opsgenie UI and assigning the person you need to contact.
 
 # General Outreach
 
 Everyone is expected to be reachable by phone during their P32 day.
-You can find phone numbers in [personio](https://giant-swarm.personio.de/staff) in the public profile.
+You can find phone numbers in [Personio](https://giant-swarm.personio.de/staff) in the public profile.


### PR DESCRIPTION
### Summary

**emergency availability page:**
- Add link checker exceptions for links to internal docs/tools.
- Fix spelling
