### PR TITLE
social media: make public

### DIFF
--- a/content/docs/content/social-media-guide/_index.md
+++ b/content/docs/content/social-media-guide/_index.md
@@ -1,0 +1,104 @@
+---
+title: Social media guide
+linkTitle: Social media guide
+weight: 30
+description: Giant Swarm guide to posting and engaging on social media
+classification: public
+expiration_in_days: 365
+---
+## Giant Swarm Social Media Guide
+
+## **Our voice**
+
+We're humans talking to humans. Whether we're sharing a technical challenge, a team moment, or industry insights, we keep it real, relatable, and rooted in our values. We're here to build connections, share knowledge, live our values, and maybe even have some fun along the way. 
+
+## **What we share**
+
+**Our stories**
+
+- Behind-the-scenes glimpses of life at Giant Swarm
+- Team adventures at conferences and events
+- Learning moments (including the times things didn't go as planned)
+- Celebrations of our people and their achievements
+- The daily reality of building and running our platform
+
+**Our knowledge**
+
+- Blog posts from our wonderful colleagues
+- Giant Conversations episodes 
+- Insights from our team's experiences
+- Industry perspectives that matter to our community
+- Event learnings and key takeaways
+
+**Our culture**
+
+- Team gatherings and celebrations
+- Remote work life
+- Learning and growth moments
+- Community involvement
+- The human side of tech
+
+## **Where we share**
+
+**LinkedIn**
+
+Our professional home base where we connect with the broader tech community. Great for sharing longer stories, company updates, and industry perspectives. We also experiment with posting blog content directly as an article on LinkedIn. 
+
+**Bluesky**
+
+Where we engage in more casual conversations, share quick insights, and connect with the tech community in a more informal way. We’re building our audience here as this is a new platform for us (and our community). 
+
+**X (Twitter)** 
+
+While we're no longer actively posting, we keep an eye on our account like on Facebook, where we post sporadically to keep the page active. 
+
+## **Posting guide**
+
+**Writing voice**
+
+- Write like you're talking to a friend who works in tech
+- It's okay to show personality and humor but try veer away from being try-hard
+- Keep it conversational but professional or keep it fun but friendly 
+
+**Sharing cadence**
+
+We aim for 2-3 posts per week on LinkedIn and Bluesky, but quality always beats quantity. If there's nothing worth saying, we don't force it.
+
+
+
+**Visual content**
+
+- Real photos > perfect photos or stock images
+- Share authentic moments from team life
+- Screenshots and diagrams when they add value or humor
+- Don't worry about perfection — authenticity matters more
+
+**Engagement**
+
+- Join conversations naturally
+- Share your genuine perspective
+- Help where we can
+- Build real connections
+- Remember the human on the other side of the screen
+
+**Good to remember**
+
+- Always consider privacy and confidentiality
+- When in doubt, ask the team
+- Be mindful of sensitive topics
+- Credit others generously
+
+## Brand advocacy
+
+We encourage all Swarmers to share their behind-the-scenes stories, projects, and insights. This helps us to develop authentic conversations while shining a spotlight on our colleagues’ achievements.
+
+- Tagging `@giantswarm` is always appreciated.
+- It sounds better from you. While we’ll always promote our colleagues’ hard work, if you’re involved in a talk, workshop, or if you’ve written a blog, it would be great if you shared it online.
+- Sharing or engaging with your colleagues’ work online is an easy way to show some love and appreciation.
+- Obviously, if you don’t want to share, or if it doesn’t feel right — don’t feel obligated to either.
+- If you want to develop your social media presence, SIG Content is here for you.
+- Offer context (and fun!) using images, GIFs, videos, screenshots.
+
+
+
+


### PR DESCRIPTION
Follow up on https://github.com/giantswarm/giantswarm/pull/32644

### Summary

Move our social media guide to the public handbook, based on its existing classification.
