### PR TITLE
docs: personio.com

### DIFF
--- a/.github/workflows/markdown-link-check.json
+++ b/.github/workflows/markdown-link-check.json
@@ -73,7 +73,7 @@
       "pattern": "https://docs.google.com/spreadsheets/d/"
     },
     {
-      "pattern": "https://giant-swarm.personio.de/staff"
+      "pattern": "https://giant-swarm.app.personio.com/staff"
     },
     {
       "pattern": "https://docs.google.com/document/d/1Ws05-gb5SESuwaAKI9gQipGmPjUoVxs_KZqEREjZcVk"

--- a/content/docs/people/p32/emergency-availablity.md
+++ b/content/docs/people/p32/emergency-availablity.md
@@ -16,4 +16,4 @@ Engineers are available through [Opsgenie](https://giantswarm.app.opsgenie.com/a
 
 # General Outreach
 
-Everyone is expected to be reachable by phone during their P32 day. You can find phone numbers in [Personio](https://giant-swarm.personio.de/staff) in the public profile.
+Everyone is expected to be reachable by phone during their P32 day. You can find phone numbers in [Personio](https://giant-swarm.app.personio.com/staff) in the public profile.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/33271

### Summary

Redirect to new http://giant-swarm.app.personio.com before Personio changes their TLD on May 15.
