### PR TITLE
Mitigate CVE-2026-42945

### DIFF
--- a/proxy/proxy-production.default.conf
+++ b/proxy/proxy-production.default.conf
@@ -41,7 +41,7 @@ http {
             root   /usr/share/nginx/html;
             # We only store compressed HTML in this directory
             # so the index directive cannot be used.
-            rewrite     ^(.*)/$ $1/index.html last;
+            rewrite     ^(?<path>.*)/$ $path/index.html last;
 
             gzip_static always;
             gunzip      on;


### PR DESCRIPTION
Mitigate https://github.com/advisories/GHSA-gcgv-v5gf-c543 by defaulting to named captures in regexp use.