### PR TITLE
chore: bump Flux API versions

### DIFF
--- a/content/docs/dev-and-releng/app-developer-processes/handle_crds_with_helm_3.md
+++ b/content/docs/dev-and-releng/app-developer-processes/handle_crds_with_helm_3.md
@@ -96,7 +96,7 @@ Below is the example of `lookup` used in [Flux app](https://github.com/giantswar
 ```yaml
 {{- $is_gitrepository_crd := (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "gitrepositories.source.toolkit.fluxcd.io") -}}
 {{- if $is_gitrepository_crd }}
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: "{{ .name }}"
@@ -160,7 +160,7 @@ previous paragraph, see below.
 ...
 {{- $is_gitrepository_crd := (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "gitrepositories.source.toolkit.fluxcd.io") -}}
 {{- if or $two_step_upgrade.unsupported $is_gitrepository_crd }}
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: "{{ .name }}"

--- a/content/docs/rfcs/multi-layer-app-config/_index.md
+++ b/content/docs/rfcs/multi-layer-app-config/_index.md
@@ -85,7 +85,7 @@ The merging algorithm is as follows:
 
 In case of multiple items in `extraConfigs` having the same priority, the order on the list is binding, with the item lower on the list being merged later (overriding those higher on the list).
 
-The idea is modeled after Flux's [HelmRelease configuration](https://fluxcd.io/docs/components/helm/api/#helm.toolkit.fluxcd.io/v2beta1.ValuesReference).
+The idea is modeled after Flux's [HelmRelease configuration](https://fluxcd.io/docs/components/helm/api/#helm.toolkit.fluxcd.io/v2.ValuesReference).
 
 #### Example
 


### PR DESCRIPTION
Towards Flux 2.7