### PR TITLE
chore: update registry-mirror spec for decommissioned giantswarmpublic.azurecr.io

### DIFF
--- a/content/docs/product/architecture-specs-adrs/specs/registry-mirror.md
+++ b/content/docs/product/architecture-specs-adrs/specs/registry-mirror.md
@@ -47,7 +47,7 @@ We address this by only using Giant Swarm-controlled registries, which only have
 
 ## What Giant Swarm-controlled registry mirrors are we using?
 
-We are using Azure Container Registry (ACR) as a Giant Swarm-controlled registry outside of China. The domain `giantswarm.azurecr.io` is for images while `giantswarmpublic.azurecr.io` is for app catalogs.
+We are using Azure Container Registry (ACR) as a Giant Swarm-controlled registry outside of China. The domain `gsoci.azurecr.io` is the current Giant Swarm registry, serving both container images (under `gsoci.azurecr.io/giantswarm/`) and app catalogs (under `gsoci.azurecr.io/charts/giantswarm/`). The former `giantswarm.azurecr.io` (images) and `giantswarmpublic.azurecr.io` (app catalogs) domains have been decommissioned.
 
 This is configured as a registry mirror, and we synchronise images between Docker Hub and Azure Container Registry (ACR).
 


### PR DESCRIPTION
### What does this PR do?

Updates the registry-mirror architecture spec, whose prose was outdated. It described `giantswarm.azurecr.io` (images) and `giantswarmpublic.azurecr.io` (app catalogs) as the registries in use, but those have been decommissioned. Both have been consolidated onto a single registry, `gsoci.azurecr.io`, which now serves container images (under `gsoci.azurecr.io/giantswarm/`) and app catalogs (under `gsoci.azurecr.io/charts/giantswarm/`). This PR updates that one sentence to reflect the current state.

### What is needed from the reviewers?

Confirm the consolidated-registry description is accurate and the wording reads well.

### Why is this piece of content here?

This is an existing architecture spec on registry mirroring; the change keeps its prose factually current.