### PR TITLE
docs: discourage -app suffix for app repositories

### DIFF
--- a/content/docs/dev-and-releng/app-developer-processes/adding_app_to_appcatalog.md
+++ b/content/docs/dev-and-releng/app-developer-processes/adding_app_to_appcatalog.md
@@ -58,7 +58,7 @@ Check below for more details about the bullets above.
 #### 1.1. Create and configure a repo for the App
 
 {{% alert title="TL;DR" color="warning" %}}
-The `-app` suffix should be in the repository name. Everywhere else, omit `-app`.
+Don't use the `-app` suffix. Name the repository and the Helm chart identically, without `-app`.
 {{% /alert %}}
 
 Use the following template repo to generate the basic skeleton for your app's repo: <https://github.com/giantswarm/template-app>.
@@ -67,14 +67,14 @@ __Note__: It is encouraged to use [devctl](https://handbook.giantswarm.io/docs/d
 
 Once created:
 
-1. Go to <https://github.com/giantswarm/APP-NAME-app/settings> and make sure `Allow merge commits` box is unchecked and `Automatically delete head branches` box is checked.
-2. Go to <https://github.com/giantswarm/APP-NAME-app/settings/access> and add
+1. Go to <https://github.com/giantswarm/APP-NAME/settings> and make sure `Allow merge commits` box is unchecked and `Automatically delete head branches` box is checked.
+2. Go to <https://github.com/giantswarm/APP-NAME/settings/access> and add
    `giantswarm/bots` with `Write` access and `giantswarm/employees` with
    `Admin` access.
 
-Note: By convention, we name app repos `[APP-NAME]-app`. [Adding the topic](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/classifying-your-repository-with-topics#adding-topics-to-your-repository) `app` to the GitHub repository is also useful. This helps the user distinguish the type of repo.
+Note: By convention, the repository and the Helm chart should be named identically, **without** the `-app` suffix (for example `myexample`, not `myexample-app`). See [Creating a new app repository](https://handbook.giantswarm.io/docs/dev-and-releng/repository/app/) for the canonical, `devctl`-based process. [Adding the topic](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/classifying-your-repository-with-topics#adding-topics-to-your-repository) `app` to the GitHub repository is also useful, as it helps users distinguish the type of repo.
 
-However, it is no longer required nor advisable to name your app and helm chart (step 2 & 3 below) with the `-app` suffix.
+The `-app` suffix is legacy. Many older repositories still carry it, but new repositories should omit it.
 
 {{% alert title="Attention" color="warning" %}}
 Omitting the `-app` suffix for default apps installed as part of a release require `cluster-operator` `>= v3.5.1` on AWS or `>= 0.23.21` on Azure and KVM.
@@ -87,7 +87,7 @@ KVM >= 13.1.0
 
 {{% /alert %}}
 
-So for `myexample` app, the app's name is `myexample` and the repo is `https://github.com/giantswarm/myexample-app`
+So for `myexample` app, the app's name, the chart name, and the repository are all `myexample` (repo: `https://github.com/giantswarm/myexample`).
 
 If you need a Go project skeleton, start with this template instead: <https://github.com/giantswarm/template>.
 


### PR DESCRIPTION
### What does this PR do?

Makes the naming guidance in *How to add and maintain App in an App Catalog* consistent with the canonical [Creating a new app repository](https://handbook.giantswarm.io/docs/dev-and-releng/repository/app/) page (updated in #424), which discourages the `-app` suffix.

Previously this page contradicted itself: the TL;DR alert and the example told you to *use* the `-app` suffix on the repository name, while a later sentence said it was "no longer advisable". Changes:

- TL;DR: recommend naming the repository and Helm chart identically, without `-app`.
- Updated the settings/access URLs from `APP-NAME-app` to `APP-NAME`.
- Replaced the "by convention we name app repos `[APP-NAME]-app`" note with the no-suffix convention, linking to the canonical repo-creation page; kept the `app` GitHub topic advice.
- Updated the `myexample` example to use `myexample` (not `myexample-app`).

The `-app` suffix is now described as legacy. The cluster-operator version caveat for default apps is left untouched.

### What is needed from the reviewers?

Confirm the no-suffix convention is the current desired state and that the legacy `cluster-operator` caveat is still worth keeping.

### Why is this piece of content here?

Correcting stale, self-contradictory naming guidance so it matches the canonical repository-creation instructions.